### PR TITLE
fix: handle error_logger metadata

### DIFF
--- a/lib/metadata_logger.ex
+++ b/lib/metadata_logger.ex
@@ -117,7 +117,7 @@ defmodule MetadataLogger do
           map()
   def log_to_map(level, message, ts, metadata) do
     with m <- Enum.into(metadata, %{}),
-         m <- Map.drop(m, [:mfa, :report_cb]),
+         m <- Map.drop(m, [:error_logger, :mfa, :report_cb]),
          {app, m} <- Map.pop(m, :application),
          {module, m} <- Map.pop(m, :module),
          {function, m} <- Map.pop(m, :function),

--- a/test/metadata_logger_test.exs
+++ b/test/metadata_logger_test.exs
@@ -125,7 +125,12 @@ defmodule MetadataLoggerTest do
         initial_call: {:hello, :world, 1},
         report_cb: & &1,
         mfa: {Foo, :bar, 1},
-        registered_name: :me
+        registered_name: :me,
+        error_logger: %{
+          report_cb: & &1,
+          tag: :info_report,
+          type: :std_info
+        }
       )
 
     assert expected == got


### PR DESCRIPTION
Recent erlang version put `error_logger` metadata with function (e.g. `report_cb`) - so let's ignore it.