### PR TITLE
Add a newline when producing a formatting error message

### DIFF
--- a/lib/metadata_logger.ex
+++ b/lib/metadata_logger.ex
@@ -71,18 +71,21 @@ defmodule MetadataLogger do
     ]
   rescue
     e ->
-      %{
-        level: "error",
-        message: "could not format json message",
-        logger_data: %{
-          exception: inspect(e),
-          level: inspect(level),
-          ts: inspect(ts),
-          message: inspect(message),
-          metadata: inspect(metadata)
+      [
+        %{
+          level: "error",
+          message: "could not format json message",
+          logger_data: %{
+            exception: inspect(e),
+            level: inspect(level),
+            ts: inspect(ts),
+            message: inspect(message),
+            metadata: inspect(metadata)
+          }
         }
-      }
-      |> Jason.encode!()
+        |> Jason.encode!(),
+        "\n"
+      ]
   end
 
   @doc """

--- a/test/metadata_logger_test.exs
+++ b/test/metadata_logger_test.exs
@@ -176,6 +176,11 @@ defmodule MetadataLoggerTest do
     assert expected == got
   end
 
+  test "Always appends a newline" do
+    assert String.ends_with?(formatted(:info, "hi",  @ts_tuple, %{}), "\n")
+    assert String.ends_with?(formatted(:info, "hi",  @ts_tuple, val: %URI{}), "\n")
+  end
+
   defp formatted(level, message, ts, metadata) do
     output_iodata = MetadataLogger.format(level, message, ts, metadata)
 


### PR DESCRIPTION
While debugging a problem in production, we realized that when metadata_logger produces a `"could not format json message"` message, it lacks a newline at the end. 

The effect is that logging parsers are unable to parse the log line as a valid JSON, since it gets grouped with the following log line.

In this PR, I've simply added a "\n" and added a test to cover this.

Thanks for this very useful library !